### PR TITLE
Fix: Printing of wheel full file name

### DIFF
--- a/pyrosettacolabsetup/__init__.py
+++ b/pyrosettacolabsetup/__init__.py
@@ -173,7 +173,7 @@ def install_pyrosetta_on_colab(prefix=_DEFAULT_PYROSETTA_GOOGLE_DRIVE_INSTALL_PR
 
     if wheels:
         wheel = pyrosetta_wheels_path + '/' + sorted(wheels)[-1]
-        print(f'Found compatible wheel: {pyrosetta_wheels_path}/{wheel}')
+        print(f'Found compatible wheel: {wheel}')
     else:
         wheel = download_pyrosetta_wheel(pyrosetta_root, pyrosetta_wheels_path)
         print(f'Installing PyRosetta wheel {wheel!r}...')


### PR DESCRIPTION
The message 
`Found compatible wheel: /content/google_drive/MyDrive/PyRosetta/colab.bin/wheels//content/google_drive/MyDrive/PyRosetta/colab.bin/wheels/pyrosetta-2022.20+release.1eb2c329089-cp37-cp37m-linux_x86_64.whl
` contains the directory prefix twice. The problem is that the path is appended twice in the printed string.